### PR TITLE
feat(rendering): shared static-scene renderer — one GL context for many envsFeat/shared static renderer

### DIFF
--- a/multi_drone_mujoco/bench/TEST.md
+++ b/multi_drone_mujoco/bench/TEST.md
@@ -1,0 +1,188 @@
+# Shared static-scene rendering — what to run
+
+Today each env builds its own `mujoco.Renderer`, so N envs = **N GL contexts and
+N identical copies of the arena in VRAM**. For a static world those copies never
+change. `SharedRenderVecEnv` runs the N envs in **M** worker processes with one
+renderer each, so VRAM scales with M instead of N — which is what lets N grow.
+
+Total rasterisation work is unchanged (still N images per step). What drops is
+context count, VRAM and CPU-side scene setup.
+
+Run everything on the **training box** (Linux/EGL, with the GPU), from the repo
+root. Numbers from any other machine are not comparable.
+
+---
+
+## 0. Setup
+
+```bash
+conda activate rl_mujoco
+pip install pynvml psutil matplotlib     # VRAM, host RAM, plots
+```
+
+All optional, but without `pynvml` you lose the VRAM curve — which is the main
+result. Install them.
+
+### Which env gets benchmarked
+
+Everything defaults to `multi_drone_mujoco.bench.env:BenchAviary` — a
+self-contained static world with a procedurally textured arena. No external
+asset files, no external dependencies beyond the package itself.
+
+**Scene weight is the knob that matters.** VRAM per GL context is driven by how
+much geometry and texture the world holds, and that is exactly what shared
+rendering saves. `BenchAviary(n_clutter=N)` sets it — default 24 textured
+boxes. A light scene *understates* the saving. Before trusting the numbers as a
+proxy for your real arena, raise `n_clutter` until per-env `vram_peak_mb` in
+step 2 is in the same range as that arena's.
+
+To benchmark a real task env instead, pass `--env 'module:Class'` to any script.
+
+---
+
+## 1. Verify correctness FIRST (~1 min)
+
+Nothing below means anything until this passes. A shared renderer that hands
+env 7's image to env 12 does not raise — it silently corrupts training.
+
+```bash
+python -m multi_drone_mujoco.bench.verify --envs 4 --steps 60
+```
+
+Runs two checks: **parity** (shared vs per-env pixels) and **cross-talk** (same
+test with the service order shuffled every step, which catches state leaking
+between envs).
+
+**Pass criteria are asymmetric, on purpose:**
+
+- **Depth must match exactly.** It encodes geometry and camera pose, so any
+  difference is a real defect — a misplaced camera or a wrong env/image
+  association shows up here immediately and hugely.
+- **RGB is judged against a measured floor.** Two independent GL contexts do
+  not produce bit-identical colour; the script first renders the same fixed
+  state repeatedly through each path to measure that GPU's own repeatability,
+  then requires the shared-vs-baseline difference to sit at or below it.
+
+Output also reports **what fraction of pixels differ** and the mean, because a
+max alone can't separate rounding from a defect: a few pixels off by 1 is
+quantisation, most of the frame off by 1 is systematic. Raise `--rgb-tol` only
+with a reason.
+
+On failure the script localises the divergence to one of three causes (A:
+physics already diverged, B: state didn't reach the renderer, C: identical
+state but different pixels) instead of just printing diffs. If it fails, stop
+and send me that block — do not run the benchmarks.
+
+---
+
+## 2. Baseline — the current path (~10–20 min)
+
+```bash
+python -m multi_drone_mujoco.bench.baseline --envs 1,2,4,8,16,30 \
+       --out runs/bench/baseline
+```
+
+Before starting: close the viewer and any training run — `nvidia-smi` should
+show no other python processes — and don't use the machine while it runs.
+
+| Output | Meaning |
+|---|---|
+| `mj_step` | physics cost (CPU; unaffected by this work) |
+| `rgb` / `depth` / `seg` | per-pass render cost |
+| `seg_share_of_render_pct` | share spent on the segmentation pass the RL obs discards |
+| `update_scene_saving_pct` | what dropping the redundant `update_scene` would save |
+| `single_renderer_rgbd_fps` | frames/s one renderer sustains |
+| `env_steps_per_sec` vs N | where throughput flattens = today's ceiling |
+| `vram_peak_mb` vs N | slope = per-env context cost — **the ceiling being removed** |
+| `vec_step.p99_ms` | latency tail |
+
+---
+
+## 3. Calibrate — pick M (~15–30 min)
+
+```bash
+python -m multi_drone_mujoco.bench.calibrate --n-envs 30 \
+       --workers 1,2,3,5,6,10,15,30 --out runs/bench/calibrate
+```
+
+Sweeps M and picks the **smallest M whose p99 step latency hasn't started
+climbing** — i.e. the fewest contexts that don't make envs wait. That's a
+measured curve, not a formula, because the whole question is how much M
+contexts contend with each other.
+
+It also tells you which architecture you're in:
+
+- **M at or above your core count** → the current grouped-worker design fits;
+  nothing more to build.
+- **M below your core count** → grouping ties up physics parallelism you could
+  otherwise use, because here M is *both* the context count and the process
+  count. Decoupling them needs a render-server design (N physics workers, M
+  render processes, images over shared memory). Not built yet — tell me if the
+  numbers land here.
+
+---
+
+## 4. Compare — old vs new (~15 min)
+
+```bash
+python -m multi_drone_mujoco.bench.compare --n-envs 30 \
+       --workers <M from step 3> --repeats 3 --out runs/bench/compare
+```
+
+Runs the two configs **interleaved** (old, new, old, new, …) rather than
+all-old-then-all-new — GPU clocks drift as the card heats, and a sequential
+layout would systematically penalise whichever ran second. It waits between
+configs so the driver actually releases VRAM before the next peak reading.
+
+Read `run-to-run spread` in the summary: **if the spread is larger than the
+difference between the two configs, the result is inconclusive** — raise
+`--repeats`.
+
+The last block extrapolates how many envs fit in your VRAM under each path.
+That's the number this whole exercise is about.
+
+---
+
+## 5. Then push N up
+
+The point of the VRAM saving is more envs. With M fixed from step 3:
+
+```bash
+python -m multi_drone_mujoco.bench.calibrate --n-envs 60 --workers <M>
+python -m multi_drone_mujoco.bench.calibrate --n-envs 100 --workers <M>
+```
+
+Watch where `env_steps_per_sec` stops rising — that's your new ceiling, and it
+should now be CPU/GPU-compute bound rather than VRAM bound.
+
+---
+
+## 6. Use it in training
+
+```python
+from multi_drone_mujoco.vec import SharedRenderVecEnv
+
+venv = SharedRenderVecEnv(env_fns, n_workers=M, want_seg=False)
+```
+
+Drop-in for `SubprocVecEnv` (same SB3 `VecEnv` API). `n_workers=len(env_fns)`
+reproduces one context per env, which is useful as a control.
+
+Note: more envs changes PPO's batch (`n_envs x n_steps`), so throughput gains
+do not convert one-for-one into faster convergence without retuning `n_steps` /
+`batch_size` / learning rate. That is out of scope here, but it is why "3x the
+env-steps/sec" will not read as "3x faster to a good policy".
+
+---
+
+## Known gaps
+
+- **The redundant `update_scene`** in `_getDroneImages` is still there
+  deliberately. `update_scene_saving_pct` prices it; removing it needs a pixel
+  test proving depth is unaffected, since a stale scene would corrupt depth
+  silently.
+- **Render server (decoupled N physics / M render)** is not built. In
+  `SharedRenderVecEnv`, M is both the GL-context count and the physics-process
+  count, so the two cannot be tuned apart. That only becomes a limitation if
+  step 3 recommends an M well below your core count — `calibrate.py` says so
+  explicitly when it does.

--- a/multi_drone_mujoco/bench/__init__.py
+++ b/multi_drone_mujoco/bench/__init__.py
@@ -1,0 +1,9 @@
+"""Render-path benchmarks.
+
+Run in this order:
+
+    verify     -- prove the shared renderer is pixel-identical (do this first)
+    baseline   -- measure the current one-renderer-per-env path
+    calibrate  -- sweep M and pick the number of shared renderers
+    compare    -- old vs new, interleaved, with plots
+"""

--- a/multi_drone_mujoco/bench/_common.py
+++ b/multi_drone_mujoco/bench/_common.py
@@ -1,0 +1,153 @@
+"""Shared helpers for the render benchmarks: GPU/RAM sampling and env loading."""
+
+from __future__ import annotations
+
+import importlib
+import statistics
+import threading
+from typing import Callable
+
+import numpy as np
+
+
+# --------------------------------------------------------------------------
+# env factory resolution
+# --------------------------------------------------------------------------
+
+# Self-contained static-world env: no external assets, no task-repo imports.
+# Override with --env 'module:Class' to benchmark a real task env instead.
+DEFAULT_ENV = "multi_drone_mujoco.bench.env:BenchAviary"
+
+
+def resolve_env_class(spec: str):
+    """Turn 'package.module:ClassName' into the class object."""
+    if ":" not in spec:
+        raise ValueError(f"env spec must be 'module:Class', got {spec!r}")
+    module_name, class_name = spec.split(":", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name)
+
+
+def make_env_factory(spec: str, rank: int, seed: int = 0) -> Callable:
+    """Picklable-by-cloudpickle factory for one env."""
+    def _init():
+        cls = resolve_env_class(spec)
+        return cls(seed=seed + rank)
+    return _init
+
+
+# --------------------------------------------------------------------------
+# GPU / host memory
+# --------------------------------------------------------------------------
+
+class GPUSampler:
+    """Background sampler for VRAM + utilisation via NVML.
+
+    No-op (fields None) when pynvml or a GPU is missing, so timing numbers are
+    still produced on a CPU-only box.
+    """
+
+    def __init__(self, device_index: int = 0, period: float = 0.1):
+        self.period = period
+        self.samples_mb: list = []
+        self.samples_util: list = []
+        self._stop = threading.Event()
+        self._thread = None
+        self._handle = None
+        try:
+            import pynvml
+            pynvml.nvmlInit()
+            self._pynvml = pynvml
+            self._handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+        except Exception:
+            self._pynvml = None
+
+    @property
+    def available(self) -> bool:
+        return self._handle is not None
+
+    def _loop(self):
+        while not self._stop.is_set():
+            try:
+                mem = self._pynvml.nvmlDeviceGetMemoryInfo(self._handle)
+                util = self._pynvml.nvmlDeviceGetUtilizationRates(self._handle)
+                self.samples_mb.append(mem.used / 1024 / 1024)
+                self.samples_util.append(util.gpu)
+            except Exception:
+                pass
+            self._stop.wait(self.period)
+
+    def __enter__(self):
+        if self.available:
+            self._stop.clear()
+            self.samples_mb, self.samples_util = [], []
+            self._thread = threading.Thread(target=self._loop, daemon=True)
+            self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        if self._thread is not None:
+            self._stop.set()
+            self._thread.join(timeout=2.0)
+
+    def report(self) -> dict:
+        if not self.samples_mb:
+            return {"vram_peak_mb": None, "vram_mean_mb": None, "gpu_util_mean_pct": None}
+        return {
+            "vram_peak_mb": round(max(self.samples_mb), 1),
+            "vram_mean_mb": round(statistics.fmean(self.samples_mb), 1),
+            "gpu_util_mean_pct": round(statistics.fmean(self.samples_util), 1),
+        }
+
+
+def host_rss_mb():
+    """RSS of this process tree in MB (None if psutil absent)."""
+    try:
+        import psutil
+    except ImportError:
+        return None
+    proc = psutil.Process()
+    total = proc.memory_info().rss
+    for child in proc.children(recursive=True):
+        try:
+            total += child.memory_info().rss
+        except Exception:
+            pass
+    return round(total / 1024 / 1024, 1)
+
+
+def gpu_info() -> dict:
+    """GPU name, total VRAM and current SM clock.
+
+    The clock is recorded so runs made at different thermal states can be
+    identified after the fact rather than silently compared.
+    """
+    try:
+        import pynvml
+        pynvml.nvmlInit()
+        h = pynvml.nvmlDeviceGetHandleByIndex(0)
+        name = pynvml.nvmlDeviceGetName(h)
+        if isinstance(name, bytes):
+            name = name.decode()
+        return {
+            "gpu_name": name,
+            "vram_total_mb": round(pynvml.nvmlDeviceGetMemoryInfo(h).total / 1024 / 1024, 1),
+            "sm_clock_mhz": pynvml.nvmlDeviceGetClockInfo(h, pynvml.NVML_CLOCK_SM),
+        }
+    except Exception:
+        return {"gpu_name": None, "vram_total_mb": None, "sm_clock_mhz": None}
+
+
+def cpu_count() -> int:
+    import os
+    return os.cpu_count() or 1
+
+
+def timing_summary(samples_s) -> dict:
+    t = np.asarray(samples_s, dtype=float) * 1e3
+    return {
+        "mean_ms": round(float(t.mean()), 3),
+        "p50_ms": round(float(np.percentile(t, 50)), 3),
+        "p99_ms": round(float(np.percentile(t, 99)), 3),
+        "max_ms": round(float(t.max()), 3),
+    }

--- a/multi_drone_mujoco/bench/baseline.py
+++ b/multi_drone_mujoco/bench/baseline.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Baseline measurement for the current one-renderer-per-env path.
+
+Answers three questions:
+
+  1. Where does a single env's step time go? (physics vs RGB vs depth vs seg)
+  2. What does one more env cost in VRAM and host RAM?
+  3. Where does env-steps/sec stop improving as N grows?
+
+(1) prices the segmentation pass that most callers discard. (2) is the ceiling
+this work exists to remove. (3) is the number the shared path has to beat.
+
+Run:
+    python -m multi_drone_mujoco.bench.baseline --envs 1,2,4,8,16,30
+"""
+
+import os
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+
+from multi_drone_mujoco.bench._common import (
+    DEFAULT_ENV, GPUSampler, cpu_count, gpu_info, host_rss_mb,
+    make_env_factory, resolve_env_class, timing_summary,
+)
+
+
+# --------------------------------------------------------------------------
+# Part 1 — single-env microbenchmark
+# --------------------------------------------------------------------------
+
+def microbench(env_spec: str, n_frames: int = 500, warmup: int = 50) -> dict:
+    """Time physics and each render pass separately, in one process."""
+    import mujoco
+
+    env = resolve_env_class(env_spec)(seed=0)
+    env.reset()
+
+    # Force the lazy renderer into existence and warm it (shader compile,
+    # texture upload) so one-off costs don't land in the measurement.
+    for _ in range(warmup):
+        env._getDroneImages(0)
+
+    r = env._renderer
+    cam = "drone0_cam"
+    data = env.data
+
+    def timed(fn, n):
+        ts = []
+        for _ in range(n):
+            t0 = time.perf_counter()
+            fn()
+            ts.append(time.perf_counter() - t0)
+        return timing_summary(ts)
+
+    def pass_rgb():
+        r.update_scene(data, camera=cam)
+        r.render()
+
+    def pass_depth():
+        r.enable_depth_rendering()
+        r.update_scene(data, camera=cam)
+        r.render()
+        r.disable_depth_rendering()
+
+    def pass_seg():
+        r.enable_segmentation_rendering()
+        r.update_scene(data, camera=cam)
+        r.render()
+        r.disable_segmentation_rendering()
+
+    def all_three():
+        pass_rgb(); pass_depth(); pass_seg()
+
+    def rgbd_two_updates():
+        pass_rgb(); pass_depth()
+
+    def rgbd_one_update():
+        # Same pixels, update_scene issued once. If this is materially faster,
+        # the extra update_scene in _getDroneImages is removable -- but only
+        # once verify.py confirms depth is unaffected.
+        r.update_scene(data, camera=cam)
+        r.render()
+        r.enable_depth_rendering()
+        r.render()
+        r.disable_depth_rendering()
+
+    results = {
+        "img_w": int(env.IMG_RES[0]),
+        "img_h": int(env.IMG_RES[1]),
+        "rgb": timed(pass_rgb, n_frames),
+        "depth": timed(pass_depth, n_frames),
+        "seg": timed(pass_seg, n_frames),
+        "rgbd_two_update_scene": timed(rgbd_two_updates, n_frames),
+        "rgbd_one_update_scene": timed(rgbd_one_update, n_frames),
+        "all_three": timed(all_three, n_frames),
+        "mj_step": timed(lambda: mujoco.mj_step(env.model, data), n_frames),
+    }
+
+    # A real env.step(): physics at sim rate + control + one observation.
+    act = np.zeros(env.action_space.shape, dtype=np.float32)
+    env.reset()
+    ts = []
+    for _ in range(n_frames):
+        t0 = time.perf_counter()
+        _, _, term, trunc, _ = env.step(act)
+        ts.append(time.perf_counter() - t0)
+        if term or trunc:
+            env.reset()
+    results["full_env_step"] = timing_summary(ts)
+
+    results["single_renderer_rgbd_fps"] = round(
+        1000.0 / results["rgbd_two_update_scene"]["mean_ms"], 1)
+    results["seg_share_of_render_pct"] = round(
+        100.0 * results["seg"]["mean_ms"] / results["all_three"]["mean_ms"], 1)
+    results["update_scene_saving_pct"] = round(
+        100.0 * (results["rgbd_two_update_scene"]["mean_ms"]
+                 - results["rgbd_one_update_scene"]["mean_ms"])
+        / max(results["rgbd_two_update_scene"]["mean_ms"], 1e-9), 1)
+
+    env.close()
+    return results
+
+
+# --------------------------------------------------------------------------
+# Part 2 — scaling sweep
+# --------------------------------------------------------------------------
+
+def sweep_one(env_spec: str, n_envs: int, steps: int, warmup: int) -> dict:
+    """Aggregate throughput for a given env count, via SubprocVecEnv.
+
+    Uses SubprocVecEnv exactly as train_window.py does, so this describes the
+    real training path rather than a synthetic proxy.
+    """
+    from stable_baselines3.common.vec_env import SubprocVecEnv
+
+    venv = SubprocVecEnv([make_env_factory(env_spec, i) for i in range(n_envs)])
+    try:
+        venv.reset()
+        act = np.zeros((n_envs,) + venv.action_space.shape, dtype=np.float32)
+
+        for _ in range(warmup):
+            venv.step(act)
+
+        with GPUSampler() as gpu:
+            times = []
+            t_start = time.perf_counter()
+            for _ in range(steps):
+                t0 = time.perf_counter()
+                venv.step(act)
+                times.append(time.perf_counter() - t0)
+            wall = time.perf_counter() - t_start
+            rss = host_rss_mb()
+            gpu_report = gpu.report()
+
+        return {
+            "n_envs": n_envs,
+            "contexts": n_envs,
+            "env_steps_per_sec": round(n_envs * steps / wall, 1),
+            "vec_step": timing_summary(times),
+            "host_rss_mb": rss,
+            **gpu_report,
+        }
+    finally:
+        venv.close()
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+def plot(report: dict, png_path: Path):
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception:
+        print("[plot] matplotlib unavailable — skipping figure")
+        return
+
+    sweep = report["sweep"]
+    n = [s["n_envs"] for s in sweep]
+    fps = [s["env_steps_per_sec"] for s in sweep]
+    vram = [s["vram_peak_mb"] for s in sweep]
+    rss = [s["host_rss_mb"] for s in sweep]
+
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4.2))
+
+    axes[0].plot(n, fps, "o-", color="tab:blue")
+    axes[0].set_title("Throughput vs env count\n(flattening = today's ceiling)")
+    axes[0].set_ylabel("env-steps / sec")
+
+    if any(v is not None for v in vram):
+        axes[1].plot(n, vram, "o-", color="tab:red", label="VRAM")
+        axes[1].set_title("Peak VRAM vs env count\n(slope = per-env context cost)")
+        if any(v is not None for v in rss):
+            ax2 = axes[1].twinx()
+            ax2.plot(n, rss, "s--", color="tab:purple", alpha=0.6)
+            ax2.set_ylabel("host RSS (MB)", color="tab:purple")
+    else:
+        axes[1].text(0.5, 0.5, "no NVML", ha="center", va="center")
+        axes[1].set_title("Peak VRAM (unavailable)")
+    axes[1].set_ylabel("MB")
+
+    for ax in axes[:2]:
+        ax.set_xlabel("n_envs")
+        ax.grid(alpha=0.3)
+
+    micro = report.get("micro")
+    if micro:
+        labels = ["mj_step", "rgb", "depth", "seg"]
+        vals = [micro["mj_step"]["mean_ms"], micro["rgb"]["mean_ms"],
+                micro["depth"]["mean_ms"], micro["seg"]["mean_ms"]]
+        axes[2].bar(labels, vals,
+                    color=["tab:green", "tab:blue", "tab:cyan", "tab:orange"])
+        axes[2].set_ylabel("ms / call")
+        axes[2].set_title(
+            f"Per-call cost @ {micro['img_w']}x{micro['img_h']}\n"
+            f"seg = {micro['seg_share_of_render_pct']}% of render, discarded")
+        axes[2].grid(alpha=0.3, axis="y")
+    else:
+        axes[2].text(0.5, 0.5, "microbench skipped", ha="center", va="center")
+
+    fig.tight_layout()
+    fig.savefig(png_path, dpi=130)
+    print(f"[plot] wrote {png_path}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env", default=DEFAULT_ENV)
+    p.add_argument("--envs", default="1,2,4,8,16,30",
+                   help="comma-separated env counts to sweep")
+    p.add_argument("--steps", type=int, default=300)
+    p.add_argument("--warmup", type=int, default=30)
+    p.add_argument("--micro-frames", type=int, default=500)
+    p.add_argument("--skip-micro", action="store_true")
+    p.add_argument("--out", default="runs/bench/baseline")
+    args = p.parse_args()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    report = {
+        "label": "baseline (one renderer per env)",
+        "env": args.env,
+        "cpu_count": cpu_count(),
+        "mujoco_gl": os.environ.get("MUJOCO_GL"),
+        **gpu_info(),
+    }
+
+    if not args.skip_micro:
+        print("[1/2] single-env microbenchmark ...")
+        m = microbench(args.env, n_frames=args.micro_frames)
+        report["micro"] = m
+        print(f"      {m['img_w']}x{m['img_h']}   "
+              f"mj_step {m['mj_step']['mean_ms']}ms   "
+              f"rgb {m['rgb']['mean_ms']}ms   "
+              f"depth {m['depth']['mean_ms']}ms   "
+              f"seg {m['seg']['mean_ms']}ms")
+        print(f"      segmentation = {m['seg_share_of_render_pct']}% of render "
+              f"time, and is discarded by the RL obs")
+        print(f"      dropping the redundant update_scene would save "
+              f"{m['update_scene_saving_pct']}% of RGB-D time")
+        print(f"      one renderer sustains {m['single_renderer_rgbd_fps']} RGB-D fps")
+
+    print("[2/2] scaling sweep ...")
+    report["sweep"] = []
+    for n in [int(x) for x in args.envs.split(",")]:
+        print(f"      n_envs={n:>3} ...", end="", flush=True)
+        row = sweep_one(args.env, n, args.steps, args.warmup)
+        report["sweep"].append(row)
+        print(f" {row['env_steps_per_sec']:>8} env-steps/s"
+              f"  VRAM {row['vram_peak_mb']} MB"
+              f"  RSS {row['host_rss_mb']} MB"
+              f"  p99 {row['vec_step']['p99_ms']} ms")
+
+    json_path = out.with_suffix(".json")
+    json_path.write_text(json.dumps(report, indent=2))
+    print(f"\n[out] wrote {json_path}")
+    plot(report, out.with_suffix(".png"))
+
+
+if __name__ == "__main__":
+    main()

--- a/multi_drone_mujoco/bench/calibrate.py
+++ b/multi_drone_mujoco/bench/calibrate.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Pick M -- the number of shared renderers -- from measured wait, not a formula.
+
+For a fixed env count N, sweeps M (worker/context count) and reports for each:
+throughput, peak VRAM, and the step-latency tail. The right M is the smallest
+one whose latency has not yet started climbing: below that, physics parallelism
+is being given up for nothing; above it, VRAM is being spent for nothing.
+
+A formula (`M = ceil(N / (R_fps / f_env))`) assumes M contexts deliver M times
+one context's throughput -- which is exactly the contention this is measuring.
+So the curve is measured rather than predicted.
+
+Run:
+    python -m multi_drone_mujoco.bench.calibrate --n-envs 30 --workers 1,2,3,5,6,10,15,30
+"""
+
+import os
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+
+from multi_drone_mujoco.bench._common import (
+    DEFAULT_ENV, GPUSampler, cpu_count, gpu_info, host_rss_mb,
+    make_env_factory, timing_summary,
+)
+
+
+def measure(env_spec: str, n_envs: int, n_workers: int, steps: int,
+            warmup: int, want_seg: bool) -> dict:
+    from multi_drone_mujoco.vec import SharedRenderVecEnv
+
+    env_fns = [make_env_factory(env_spec, i) for i in range(n_envs)]
+    venv = SharedRenderVecEnv(env_fns, n_workers=n_workers, want_seg=want_seg)
+    try:
+        venv.reset()
+        act = np.zeros((n_envs,) + venv.action_space.shape, dtype=np.float32)
+
+        for _ in range(warmup):
+            venv.step(act)
+
+        with GPUSampler() as gpu:
+            times = []
+            t_start = time.perf_counter()
+            for _ in range(steps):
+                t0 = time.perf_counter()
+                venv.step(act)
+                times.append(time.perf_counter() - t0)
+            wall = time.perf_counter() - t_start
+            rss = host_rss_mb()
+            gpu_report = gpu.report()
+
+        render = venv.render_stats()
+        envs_per_worker = [len(g) for g in venv.groups]
+
+        return {
+            "n_workers": n_workers,
+            "envs_per_worker_max": max(envs_per_worker),
+            "env_steps_per_sec": round(n_envs * steps / wall, 1),
+            "vec_step": timing_summary(times),
+            "host_rss_mb": rss,
+            "renderer_raster_mean_ms": round(
+                float(np.mean([r["raster_mean_ms"] for r in render if r])), 4),
+            "renderer_raster_p99_ms": round(
+                float(np.max([r["raster_p99_ms"] for r in render if r])), 4),
+            **gpu_report,
+        }
+    finally:
+        venv.close()
+
+
+def choose_m(rows: list, tolerance: float = 0.05) -> dict:
+    """Smallest M whose p99 step latency is within `tolerance` of the best seen.
+
+    Latency, not throughput, because the stated goal is that envs should not sit
+    waiting on a renderer.
+    """
+    usable = [r for r in rows if r.get("vec_step")]
+    if not usable:
+        return {}
+    best_p99 = min(r["vec_step"]["p99_ms"] for r in usable)
+    ceiling = best_p99 * (1.0 + tolerance)
+    winners = [r for r in usable if r["vec_step"]["p99_ms"] <= ceiling]
+    pick = min(winners, key=lambda r: r["n_workers"])
+    return {
+        "recommended_workers": pick["n_workers"],
+        "best_p99_ms": best_p99,
+        "accepted_p99_ms": pick["vec_step"]["p99_ms"],
+        "tolerance": tolerance,
+        "vram_peak_mb": pick["vram_peak_mb"],
+        "env_steps_per_sec": pick["env_steps_per_sec"],
+    }
+
+
+def plot(report: dict, png_path: Path):
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception:
+        print("[plot] matplotlib unavailable — skipping figure")
+        return
+
+    rows = report["sweep"]
+    m = [r["n_workers"] for r in rows]
+    fps = [r["env_steps_per_sec"] for r in rows]
+    p99 = [r["vec_step"]["p99_ms"] for r in rows]
+    vram = [r["vram_peak_mb"] for r in rows]
+    rec = report.get("recommendation", {}).get("recommended_workers")
+
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4.2))
+
+    for ax, y, title, ylab, color in (
+        (axes[0], fps, "Throughput vs M", "env-steps / sec", "tab:blue"),
+        (axes[1], p99, "Step latency tail vs M\n(the 'waiting' to minimise)",
+         "p99 vec step (ms)", "tab:orange"),
+        (axes[2], vram, "Peak VRAM vs M\n(cost of each extra context)",
+         "MB", "tab:red"),
+    ):
+        if any(v is None for v in y):
+            ax.text(0.5, 0.5, "no NVML", ha="center", va="center")
+        else:
+            ax.plot(m, y, "o-", color=color)
+        if rec is not None:
+            ax.axvline(rec, ls="--", color="k", alpha=0.5)
+            ax.annotate(f"M={rec}", xy=(rec, ax.get_ylim()[1]),
+                        xytext=(3, -12), textcoords="offset points", fontsize=9)
+        ax.set_xlabel("M (workers / GL contexts)")
+        ax.set_ylabel(ylab)
+        ax.set_title(title)
+        ax.grid(alpha=0.3)
+
+    fig.suptitle(f"N = {report['n_envs']} envs", y=1.02)
+    fig.tight_layout()
+    fig.savefig(png_path, dpi=130, bbox_inches="tight")
+    print(f"[plot] wrote {png_path}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env", default=DEFAULT_ENV)
+    p.add_argument("--n-envs", type=int, default=30)
+    p.add_argument("--workers", default="",
+                   help="comma-separated M values (default: divisors-ish of N)")
+    p.add_argument("--steps", type=int, default=200)
+    p.add_argument("--warmup", type=int, default=30)
+    p.add_argument("--seg", action="store_true")
+    p.add_argument("--tolerance", type=float, default=0.05,
+                   help="accept M whose p99 is within this fraction of the best")
+    p.add_argument("--out", default="runs/bench/calibrate", help="base path for .json and .png output")
+    args = p.parse_args()
+
+    n = args.n_envs
+    if args.workers:
+        ms = [int(x) for x in args.workers.split(",")]
+    else:
+        ms = sorted({m for m in (1, 2, 3, 4, 5, 6, 8, 10, 15, n) if 1 <= m <= n})
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    report = {
+        "label": "shared renderer — M sweep",
+        "env": args.env,
+        "n_envs": n,
+        "want_seg": args.seg,
+        "cpu_count": cpu_count(),
+        "mujoco_gl": os.environ.get("MUJOCO_GL"),
+        **gpu_info(),
+        "sweep": [],
+    }
+
+    print(f"N={n} envs, sweeping M over {ms}  (cpu cores: {report['cpu_count']})\n")
+    for m in ms:
+        print(f"  M={m:>3} ...", end="", flush=True)
+        row = measure(args.env, n, m, args.steps, args.warmup, args.seg)
+        report["sweep"].append(row)
+        print(f" {row['env_steps_per_sec']:>8} env-steps/s"
+              f"  p99 {row['vec_step']['p99_ms']:>7} ms"
+              f"  VRAM {row['vram_peak_mb']} MB"
+              f"  RSS {row['host_rss_mb']} MB")
+
+    report["recommendation"] = choose_m(report["sweep"], args.tolerance)
+    rec = report["recommendation"]
+
+    print()
+    if rec:
+        print(f"Recommended M = {rec['recommended_workers']}"
+              f"  (p99 {rec['accepted_p99_ms']} ms vs best {rec['best_p99_ms']} ms,"
+              f"  VRAM {rec['vram_peak_mb']} MB)")
+        if rec["recommended_workers"] >= report["cpu_count"]:
+            print("  M is at/above your core count — the simple grouped-worker")
+            print("  design is the right fit; a render server would not help.")
+        else:
+            print("  M is below your core count, so grouping ties up physics")
+            print("  parallelism you could otherwise use. If throughput matters")
+            print("  more than VRAM here, a decoupled render server is the next step.")
+
+    json_path = out.with_suffix(".json")
+    json_path.write_text(json.dumps(report, indent=2))
+    print(f"\n[out] wrote {json_path}")
+    plot(report, out.with_suffix(".png"))
+
+
+if __name__ == "__main__":
+    main()

--- a/multi_drone_mujoco/bench/compare.py
+++ b/multi_drone_mujoco/bench/compare.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Old vs new, head to head: SubprocVecEnv (N contexts) vs shared renderer (M).
+
+Runs both configurations **interleaved** (old, new, old, new, ...) rather than
+all-old-then-all-new. GPU clocks drift as the card heats, so a sequential layout
+systematically penalises whichever variant ran second; interleaving spreads that
+drift across both and the per-repeat spread shows how much it mattered.
+
+Reports throughput, step-latency tail, peak VRAM and host RSS for each, plus the
+headroom the VRAM saving buys -- an estimate of how many envs would now fit.
+
+Run (after verify.py passes):
+    python -m multi_drone_mujoco.bench.compare --n-envs 30 --workers 6 --repeats 3
+"""
+
+import os
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import argparse
+import gc
+import json
+import statistics
+import time
+from pathlib import Path
+
+import numpy as np
+
+from multi_drone_mujoco.bench._common import (
+    DEFAULT_ENV, GPUSampler, cpu_count, gpu_info, host_rss_mb,
+    make_env_factory, timing_summary,
+)
+
+
+def _run(venv, n_envs: int, steps: int, warmup: int) -> dict:
+    venv.reset()
+    act = np.zeros((n_envs,) + venv.action_space.shape, dtype=np.float32)
+
+    for _ in range(warmup):
+        venv.step(act)
+
+    with GPUSampler() as gpu:
+        times = []
+        t_start = time.perf_counter()
+        for _ in range(steps):
+            t0 = time.perf_counter()
+            venv.step(act)
+            times.append(time.perf_counter() - t0)
+        wall = time.perf_counter() - t_start
+        rss = host_rss_mb()
+        report = gpu.report()
+
+    return {
+        "env_steps_per_sec": round(n_envs * steps / wall, 1),
+        "vec_step": timing_summary(times),
+        "host_rss_mb": rss,
+        **report,
+    }
+
+
+def run_baseline(env_spec: str, n_envs: int, steps: int, warmup: int) -> dict:
+    from stable_baselines3.common.vec_env import SubprocVecEnv
+
+    venv = SubprocVecEnv([make_env_factory(env_spec, i) for i in range(n_envs)])
+    try:
+        out = _run(venv, n_envs, steps, warmup)
+        out["contexts"] = n_envs
+        return out
+    finally:
+        venv.close()
+
+
+def run_shared(env_spec: str, n_envs: int, n_workers: int, steps: int,
+               warmup: int, want_seg: bool) -> dict:
+    from multi_drone_mujoco.vec import SharedRenderVecEnv
+
+    venv = SharedRenderVecEnv(
+        [make_env_factory(env_spec, i) for i in range(n_envs)],
+        n_workers=n_workers, want_seg=want_seg,
+    )
+    try:
+        out = _run(venv, n_envs, steps, warmup)
+        out["contexts"] = n_workers
+        return out
+    finally:
+        venv.close()
+
+
+def _settle(pause: float):
+    """Let the driver actually release VRAM before the next configuration.
+
+    Without this the next run's peak reading includes the previous run's
+    not-yet-freed allocations.
+    """
+    gc.collect()
+    time.sleep(pause)
+
+
+def aggregate(runs: list) -> dict:
+    """Median across repeats, plus spread (how much clock drift moved things)."""
+    fps = [r["env_steps_per_sec"] for r in runs]
+    p99 = [r["vec_step"]["p99_ms"] for r in runs]
+    vram = [r["vram_peak_mb"] for r in runs if r["vram_peak_mb"] is not None]
+    rss = [r["host_rss_mb"] for r in runs if r["host_rss_mb"] is not None]
+    return {
+        "repeats": len(runs),
+        "contexts": runs[0]["contexts"],
+        "env_steps_per_sec_median": round(statistics.median(fps), 1),
+        "env_steps_per_sec_spread_pct": round(
+            100.0 * (max(fps) - min(fps)) / max(statistics.median(fps), 1e-9), 1),
+        "vec_step_p99_ms_median": round(statistics.median(p99), 3),
+        "vram_peak_mb_median": round(statistics.median(vram), 1) if vram else None,
+        "host_rss_mb_median": round(statistics.median(rss), 1) if rss else None,
+    }
+
+
+def plot(report: dict, png_path: Path):
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception:
+        print("[plot] matplotlib unavailable — skipping figure")
+        return
+
+    b, s = report["baseline"], report["shared"]
+    labels = [f"baseline\n{b['contexts']} contexts", f"shared\n{s['contexts']} contexts"]
+    colors = ["tab:gray", "tab:green"]
+
+    metrics = [
+        ("env_steps_per_sec_median", "env-steps / sec", "Throughput (higher better)"),
+        ("vec_step_p99_ms_median", "p99 vec step (ms)", "Latency tail (lower better)"),
+        ("vram_peak_mb_median", "MB", "Peak VRAM (lower better)"),
+        ("host_rss_mb_median", "MB", "Host RSS (lower better)"),
+    ]
+
+    fig, axes = plt.subplots(1, 4, figsize=(18, 4.2))
+    for ax, (key, ylab, title) in zip(axes, metrics):
+        vals = [b.get(key), s.get(key)]
+        if any(v is None for v in vals):
+            ax.text(0.5, 0.5, "unavailable", ha="center", va="center")
+        else:
+            bars = ax.bar(labels, vals, color=colors)
+            for bar, v in zip(bars, vals):
+                ax.annotate(f"{v:g}", xy=(bar.get_x() + bar.get_width() / 2, v),
+                            xytext=(0, 3), textcoords="offset points",
+                            ha="center", fontsize=9)
+            if vals[0]:
+                delta = 100.0 * (vals[1] - vals[0]) / vals[0]
+                ax.set_xlabel(f"{delta:+.1f}% vs baseline")
+        ax.set_ylabel(ylab)
+        ax.set_title(title)
+        ax.grid(alpha=0.3, axis="y")
+
+    fig.suptitle(
+        f"N = {report['n_envs']} envs   |   {report['repeats']} interleaved repeats",
+        y=1.03)
+    fig.tight_layout()
+    fig.savefig(png_path, dpi=130, bbox_inches="tight")
+    print(f"[plot] wrote {png_path}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env", default=DEFAULT_ENV)
+    p.add_argument("--n-envs", type=int, default=30)
+    p.add_argument("--workers", type=int, required=True,
+                   help="M — take this from calibrate.py's recommendation")
+    p.add_argument("--steps", type=int, default=200)
+    p.add_argument("--warmup", type=int, default=30)
+    p.add_argument("--repeats", type=int, default=3)
+    p.add_argument("--settle", type=float, default=3.0,
+                   help="seconds between configs, so VRAM is actually released")
+    p.add_argument("--seg", action="store_true")
+    p.add_argument("--out", default="runs/bench/compare")
+    args = p.parse_args()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    report = {
+        "env": args.env,
+        "n_envs": args.n_envs,
+        "workers": args.workers,
+        "repeats": args.repeats,
+        "want_seg": args.seg,
+        "cpu_count": cpu_count(),
+        "mujoco_gl": os.environ.get("MUJOCO_GL"),
+        **gpu_info(),
+        "baseline_runs": [],
+        "shared_runs": [],
+    }
+
+    print(f"N={args.n_envs}  M={args.workers}  repeats={args.repeats} (interleaved)\n")
+
+    for rep in range(args.repeats):
+        print(f"  repeat {rep + 1}/{args.repeats}")
+
+        print("    baseline (one renderer per env) ...", end="", flush=True)
+        r = run_baseline(args.env, args.n_envs, args.steps, args.warmup)
+        report["baseline_runs"].append(r)
+        print(f" {r['env_steps_per_sec']} env-steps/s  VRAM {r['vram_peak_mb']} MB")
+        _settle(args.settle)
+
+        print("    shared   (M renderers)          ...", end="", flush=True)
+        r = run_shared(args.env, args.n_envs, args.workers, args.steps,
+                       args.warmup, args.seg)
+        report["shared_runs"].append(r)
+        print(f" {r['env_steps_per_sec']} env-steps/s  VRAM {r['vram_peak_mb']} MB")
+        _settle(args.settle)
+
+    report["baseline"] = aggregate(report["baseline_runs"])
+    report["shared"] = aggregate(report["shared_runs"])
+
+    b, s = report["baseline"], report["shared"]
+    print("\n" + "=" * 66)
+    print(f"{'metric':<28}{'baseline':>16}{'shared':>16}")
+    print("-" * 66)
+    for key, name in (
+        ("contexts", "GL contexts"),
+        ("env_steps_per_sec_median", "env-steps/sec"),
+        ("vec_step_p99_ms_median", "p99 step (ms)"),
+        ("vram_peak_mb_median", "peak VRAM (MB)"),
+        ("host_rss_mb_median", "host RSS (MB)"),
+    ):
+        print(f"{name:<28}{str(b.get(key)):>16}{str(s.get(key)):>16}")
+    print("=" * 66)
+    print(f"run-to-run spread: baseline {b['env_steps_per_sec_spread_pct']}%,"
+          f" shared {s['env_steps_per_sec_spread_pct']}%"
+          "   (larger than the difference => inconclusive)")
+
+    # What the VRAM saving actually buys: the point of the exercise.
+    if b.get("vram_peak_mb_median") and s.get("vram_peak_mb_median"):
+        total = report.get("vram_total_mb")
+        per_env_base = b["vram_peak_mb_median"] / args.n_envs
+        per_env_shared = s["vram_peak_mb_median"] / args.n_envs
+        print(f"\nVRAM per env: {per_env_base:.1f} MB -> {per_env_shared:.1f} MB")
+        if total:
+            print(f"envs that fit in {total:.0f} MB (linear extrapolation, "
+                  f"physics/CPU limits aside):")
+            print(f"    baseline ~{int(total / max(per_env_base, 1e-9))}"
+                  f"    shared ~{int(total / max(per_env_shared, 1e-9))}")
+
+    json_path = out.with_suffix(".json")
+    json_path.write_text(json.dumps(report, indent=2))
+    print(f"\n[out] wrote {json_path}")
+    plot(report, out.with_suffix(".png"))
+
+
+if __name__ == "__main__":
+    main()

--- a/multi_drone_mujoco/bench/env.py
+++ b/multi_drone_mujoco/bench/env.py
@@ -1,0 +1,203 @@
+"""A self-contained static-world env for benchmarking the render path.
+
+Why this exists rather than benchmarking a task env: the shared renderer's whole
+premise is a *static, identical* world across envs, and the measurement that
+matters is VRAM per GL context -- which is dominated by how much geometry and
+texture the scene holds. So the bench env needs a scene whose weight can be
+dialled up, and it must not depend on any external asset files.
+
+Everything here is procedural: MuJoCo's builtin checker/flat texture generators
+produce real texture memory without a single file on disk. `n_clutter` controls
+how many textured boxes the arena holds, so you can match the weight of the
+world you actually train on.
+
+The observation deliberately mirrors a vision policy's: RGB-D image plus a small
+proprioception vector, so per-step cost is representative.
+
+    from multi_drone_mujoco.bench.env import BenchAviary
+    env = BenchAviary(img_w=96, img_h=96, n_clutter=24)
+
+Scene weight is a benchmark parameter
+-------------------------------------
+A near-empty world understates VRAM per context and therefore understates what
+shared rendering saves. If you are sizing this against a specific arena, raise
+`n_clutter` until `vram_peak_mb` per env in bench/baseline.py is in the same
+range as that arena's.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import gymnasium as gym
+from gymnasium import spaces
+import mujoco
+
+from multi_drone_mujoco.envs import base_aviary as _BA
+from multi_drone_mujoco.envs.base_aviary import BaseAviary
+from multi_drone_mujoco.utils.enums import (
+    DroneModel, Physics, ActionType, ObservationType,
+)
+
+
+def _clutter_xml(n: int, seed: int = 0) -> tuple:
+    """Deterministic procedural clutter: (asset_xml, body_xml).
+
+    Placement is a fixed function of the index -- never random -- because every
+    env must produce a byte-identical world for shared rendering to be valid.
+    """
+    assets, bodies = [], []
+    for i in range(n):
+        # Deterministic spread on a spiral, well clear of the drone's spawn.
+        ang = 2.399963 * i           # golden angle, gives an even spread
+        rad = 1.2 + 0.35 * (i % 7)
+        x, y = rad * np.cos(ang), rad * np.sin(ang)
+        z = 0.25 + 0.30 * (i % 5)
+        r, g, b = 0.25 + 0.5 * ((i * 7) % 5) / 4.0, \
+                  0.25 + 0.5 * ((i * 3) % 4) / 3.0, \
+                  0.25 + 0.5 * ((i * 5) % 6) / 5.0
+        kind = "checker" if i % 2 == 0 else "gradient"
+        assets.append(
+            f'    <texture name="bench_tex_{i}" type="2d" builtin="{kind}" '
+            f'width="256" height="256" rgb1="{r:.3f} {g:.3f} {b:.3f}" '
+            f'rgb2="{b:.3f} {r:.3f} {g:.3f}"/>\n'
+            f'    <material name="bench_mat_{i}" texture="bench_tex_{i}" '
+            f'texrepeat="3 3" specular="0.3" shininess="0.4"/>'
+        )
+        bodies.append(
+            f'    <body name="bench_clutter_{i}" pos="{x:.4f} {y:.4f} {z:.4f}">\n'
+            f'      <geom type="box" size="0.12 0.12 {0.15 + 0.05 * (i % 4):.3f}" '
+            f'material="bench_mat_{i}" contype="0" conaffinity="0"/>\n'
+            f'    </body>'
+        )
+    return "\n".join(assets), "\n".join(bodies)
+
+
+def _make_injector(n_clutter: int):
+    """Wrap _generate_aviary_xml so the clutter is spliced into the model.
+
+    Same mechanism the task envs use: patch the module-level builder for the
+    duration of construction, then restore it.
+    """
+    original = _BA._generate_aviary_xml
+
+    def patched(*args, **kwargs):
+        xml = original(*args, **kwargs)
+        if n_clutter <= 0:
+            return xml
+        asset_xml, body_xml = _clutter_xml(n_clutter)
+        if "</asset>" not in xml or "</worldbody>" not in xml:
+            raise RuntimeError(
+                "BenchAviary: generated XML has no <asset>/<worldbody> to splice "
+                "into — the base XML layout changed."
+            )
+        xml = xml.replace("</asset>", asset_xml + "\n  </asset>", 1)
+        xml = xml.replace("</worldbody>", body_xml + "\n  </worldbody>", 1)
+        return xml
+
+    return original, patched
+
+
+class BenchAviary(BaseAviary):
+    """Single drone, static procedural world, RGB-D + proprio observation.
+
+    Parameters
+    ----------
+    img_w, img_h : int
+        Onboard camera resolution. Defaults match a typical vision policy.
+    n_clutter : int
+        Number of textured boxes in the arena. Controls scene weight, and so
+        VRAM per GL context -- the quantity shared rendering reduces.
+    depth_max : float
+        Depth clip (m) for packing depth into the 4th image channel.
+    seed : int
+        Only seeds the action/reset RNG. The *world* is identical regardless,
+        which is what makes shared rendering valid.
+    """
+
+    IMG_W, IMG_H = 96, 96
+
+    def __init__(self, img_w: int = 96, img_h: int = 96, n_clutter: int = 24,
+                 depth_max: float = 8.0, seed: int = None,
+                 sim_freq: int = 240, ctrl_freq: int = 48):
+        self.IMG_W, self.IMG_H = int(img_w), int(img_h)
+        self.DEPTH_MAX = float(depth_max)
+        self.N_CLUTTER = int(n_clutter)
+        self._rng = np.random.default_rng(seed)
+        self.EPISODE_LEN_SEC = 30      # long, so resets don't dominate timings
+
+        original, patched = _make_injector(self.N_CLUTTER)
+        _BA._generate_aviary_xml = patched
+        try:
+            super().__init__(
+                drone_model=DroneModel.CF2X,
+                num_drones=1,
+                initial_xyzs=np.array([[0.0, 0.0, 1.0]]),
+                initial_rpys=np.array([[0.0, 0.0, 0.0]]),
+                physics=Physics.MJC,
+                sim_freq=sim_freq, ctrl_freq=ctrl_freq,
+                vision_attributes=True,
+                obs_type=ObservationType.KIN,
+                act_type=ActionType.RPM,
+            )
+        finally:
+            _BA._generate_aviary_xml = original
+
+        # BaseAviary forces 256x256 when vision_attributes is on; the renderer
+        # is built lazily from IMG_RES, so overriding it here takes effect.
+        self.IMG_RES = np.array([self.IMG_W, self.IMG_H])
+
+    # -- spaces ------------------------------------------------------------
+
+    def _observationSpace(self):
+        return spaces.Dict({
+            "image": spaces.Box(0, 255, shape=(self.IMG_H, self.IMG_W, 4), dtype=np.uint8),
+            "proprio": spaces.Box(-np.inf, np.inf, shape=(9,), dtype=np.float32),
+        })
+
+    def _actionSpace(self):
+        return spaces.Box(-1.0, 1.0, shape=(4,), dtype=np.float32)
+
+    def _preprocessAction(self, action):
+        """Map [-1,1] onto a small band around hover.
+
+        Keeps the drone airborne and roughly in place so the camera keeps seeing
+        the scene -- a drone on the floor would render a degenerate view and
+        misrepresent the cost.
+        """
+        a = np.clip(np.asarray(action, dtype=float).flatten(), -1.0, 1.0)
+        rpm = self.HOVER_RPM * (1.0 + 0.03 * a)
+        return np.clip(rpm, 0, self.MAX_RPM).reshape(1, 4)
+
+    # -- observation -------------------------------------------------------
+
+    def _computeObs(self):
+        rgb, dep, _ = self._getDroneImages(0)
+        depth_u8 = (np.clip(dep, 0.0, self.DEPTH_MAX) / self.DEPTH_MAX * 255.0).astype(np.uint8)
+        image = np.concatenate([rgb[..., :3], depth_u8[..., None]], axis=2)
+
+        R = np.zeros(9)
+        mujoco.mju_quat2Mat(R, self.quat[0])
+        R = R.reshape(3, 3)
+        grav_body = R.T @ np.array([0.0, 0.0, -1.0])
+        angv_body = R.T @ self.ang_v[0]
+        vel_body = R.T @ self.vel[0]
+        proprio = np.concatenate([grav_body, angv_body, vel_body]).astype(np.float32)
+
+        return {"image": image, "proprio": proprio}
+
+    # -- task stubs --------------------------------------------------------
+    # There is no task here: this env exists to be stepped and rendered, so the
+    # reward is constant and episodes only end on the time limit. That keeps
+    # resets out of the timing measurements.
+
+    def _computeReward(self):
+        return 0.0
+
+    def _computeTerminated(self):
+        return False
+
+    def _computeTruncated(self):
+        return self.step_counter / self.SIM_FREQ > self.EPISODE_LEN_SEC
+
+    def _computeInfo(self):
+        return {}

--- a/multi_drone_mujoco/bench/verify.py
+++ b/multi_drone_mujoco/bench/verify.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Prove the shared renderer produces the same pixels as the per-env renderer.
+
+This must pass before any speed number from compare.py means anything. A shared
+renderer that mixes up which image belongs to which env does not raise -- it
+silently feeds the policy the wrong observation and training just gets worse.
+
+Two checks:
+
+  1. **Parity** -- K envs stepped through identical action sequences, once with
+     per-env renderers and once through one shared renderer. Every RGB and
+     depth frame must match exactly.
+
+  2. **No cross-talk** -- the same test, but the order in which the shared
+     renderer serves envs is shuffled every step. If any per-env state leaks
+     across calls, differing service order changes the output and this fails
+     while check 1 passes.
+
+On failure it localises the divergence rather than leaving you to guess. There
+are only three places it can come from, and they are checked in order:
+
+  A. the two envs' *physics* already differ  -> the test is invalid, not the
+     renderer
+  B. the env's state did not reach the renderer's scratch data intact -> the
+     state-transfer step is wrong
+  C. neither -> identical state, different pixels: a renderer *configuration*
+     difference (scene options, lighting, buffer setup)
+
+Run:
+    python -m multi_drone_mujoco.bench.verify --envs 4 --steps 60
+    python -m multi_drone_mujoco.bench.verify --state-transfer minimal
+"""
+
+import os
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import argparse
+import sys
+
+import numpy as np
+
+from multi_drone_mujoco.bench._common import DEFAULT_ENV, resolve_env_class
+from multi_drone_mujoco.rendering import SharedStaticRenderer
+
+
+def _maxdiff(a, b) -> float:
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    if a.shape != b.shape:
+        return float("inf")
+    return float(np.abs(a - b).max()) if a.size else 0.0
+
+
+def _rgb_stats(a, b) -> dict:
+    """Max, mean and spread of an RGB difference.
+
+    The max alone cannot distinguish rounding from a real defect: a handful of
+    pixels off by 1 is quantisation, most of the frame off by 1 is systematic.
+    """
+    d = np.abs(a.astype(np.int32) - b.astype(np.int32))
+    return {
+        "max": int(d.max()),
+        "mean": float(d.mean()),
+        "frac_differing": float((d > 0).mean()),
+    }
+
+
+def measure_noise_floor(env, renderer, n: int = 8) -> dict:
+    """Empirical repeatability of each render path, with state held fixed.
+
+    Renders the same unchanged state repeatedly through the per-env renderer and
+    through the shared renderer. Whatever difference shows up here is the
+    floor -- GPU/driver non-determinism that no implementation can remove. A
+    shared-vs-baseline difference at or below this floor carries no information.
+    """
+    saved = env._external_renderer
+    floors = {}
+
+    env._external_renderer = None
+    ref_rgb, ref_dep, _ = env._getDroneImages(0)
+    rgb_max = dep_max = 0.0
+    for _ in range(n):
+        rgb, dep, _ = env._getDroneImages(0)
+        rgb_max = max(rgb_max, _maxdiff(ref_rgb, rgb))
+        dep_max = max(dep_max, _maxdiff(ref_dep, dep))
+    floors["per_env_renderer"] = {"rgb": rgb_max, "depth": dep_max}
+
+    env._external_renderer = renderer
+    ref_rgb, ref_dep, _ = env._getDroneImages(0)
+    rgb_max = dep_max = 0.0
+    for _ in range(n):
+        rgb, dep, _ = env._getDroneImages(0)
+        rgb_max = max(rgb_max, _maxdiff(ref_rgb, rgb))
+        dep_max = max(dep_max, _maxdiff(ref_dep, dep))
+    floors["shared_renderer"] = {"rgb": rgb_max, "depth": dep_max}
+
+    env._external_renderer = saved
+    floors["rgb"] = max(floors["per_env_renderer"]["rgb"],
+                        floors["shared_renderer"]["rgb"])
+    floors["depth"] = max(floors["per_env_renderer"]["depth"],
+                          floors["shared_renderer"]["depth"])
+    return floors
+
+
+def _diagnose(base_env, shared_env, renderer) -> dict:
+    """Localise a mismatch. Call immediately after rendering `shared_env`.
+
+    The renderer's scratch data still holds what was actually rasterised, so
+    comparing env -> scratch -> base pins down which link broke.
+    """
+    b, s, scratch = base_env.data, shared_env.data, renderer._scratch
+
+    physics = {
+        "qpos": _maxdiff(b.qpos, s.qpos),
+        "qvel": _maxdiff(b.qvel, s.qvel),
+    }
+    transfer = {
+        "qpos": _maxdiff(s.qpos, scratch.qpos),
+        "cam_xpos": _maxdiff(s.cam_xpos, scratch.cam_xpos),
+        "cam_xmat": _maxdiff(s.cam_xmat, scratch.cam_xmat),
+        "geom_xpos": _maxdiff(s.geom_xpos, scratch.geom_xpos),
+        "geom_xmat": _maxdiff(s.geom_xmat, scratch.geom_xmat),
+        "light_xpos": _maxdiff(s.light_xpos, scratch.light_xpos)
+                      if renderer.model.nlight else 0.0,
+    }
+
+    if max(physics.values()) > 0:
+        verdict = ("A: the two envs' physics already diverged — the comparison "
+                   "is invalid, fix the test setup before blaming the renderer")
+    elif max(transfer.values()) > 0:
+        worst = max(transfer, key=transfer.get)
+        verdict = (f"B: env state did not reach the renderer intact "
+                   f"(worst field: {worst} = {transfer[worst]:.6g}) — the "
+                   f"state-transfer step is incomplete")
+    else:
+        verdict = ("C: identical state, different pixels — a renderer "
+                   "configuration difference (scene options / lighting / "
+                   "buffer setup), not a state problem")
+
+    return {"physics": physics, "transfer": transfer, "verdict": verdict}
+
+
+def run_check(env_cls, k: int, steps: int, seed: int, shuffle: bool,
+              want_seg: bool, state_transfer: str, rgb_tol: int) -> dict:
+    base_envs = [env_cls(seed=seed + i) for i in range(k)]
+    shared_envs = [env_cls(seed=seed + i) for i in range(k)]
+
+    # Baseline envs keep their own renderers; make them render the same passes
+    # the shared path will, so the comparison is like-for-like.
+    for e in base_envs:
+        e._render_seg = want_seg
+
+    head = shared_envs[0]
+    renderer = SharedStaticRenderer(
+        head.model, width=int(head.IMG_RES[0]), height=int(head.IMG_RES[1]),
+        want_seg=want_seg, state_transfer=state_transfer,
+    )
+    for e in shared_envs:
+        renderer.assert_compatible(e.model, "drone0_cam")
+        e._external_renderer = renderer
+        e._render_seg = want_seg
+
+    for e in base_envs + shared_envs:
+        e.reset(seed=seed)
+
+    # Establish what "identical" can even mean on this GPU before judging.
+    noise = measure_noise_floor(shared_envs[0], renderer)
+    rgb_gate = max(int(np.ceil(noise["rgb"])), rgb_tol)
+
+    rng = np.random.default_rng(seed)
+    order_rng = np.random.default_rng(seed + 9999)
+
+    worst_rgb, worst_dep = 0, 0.0
+    mismatched_steps, compared = 0, 0
+    diagnosis = None
+    worst_stats = {"max": 0, "mean": 0.0, "frac_differing": 0.0}
+
+    try:
+        for _ in range(steps):
+            actions = [rng.uniform(-1, 1, size=base_envs[0].action_space.shape
+                                   ).astype(np.float32) for _ in range(k)]
+            for e, a in zip(base_envs, actions):
+                e.step(a)
+            for e, a in zip(shared_envs, actions):
+                e.step(a)
+
+            order = list(range(k))
+            if shuffle:
+                order_rng.shuffle(order)
+
+            step_bad = False
+            for i in order:
+                # Shared first, so the scratch data still describes this env
+                # if we need to diagnose.
+                s_rgb, s_dep, _ = shared_envs[i]._getDroneImages(0)
+                snapshot = (_diagnose(base_envs[i], shared_envs[i], renderer)
+                            if diagnosis is None else None)
+                b_rgb, b_dep, _ = base_envs[i]._getDroneImages(0)
+
+                stats = _rgb_stats(b_rgb, s_rgb)
+                d_rgb = stats["max"]
+                d_dep = float(np.abs(b_dep - s_dep).max())
+                worst_rgb = max(worst_rgb, d_rgb)
+                worst_dep = max(worst_dep, d_dep)
+                if stats["frac_differing"] > worst_stats["frac_differing"]:
+                    worst_stats = stats
+                compared += 1
+
+                # Depth must be exact -- it encodes geometry and camera pose, so
+                # any difference there is a real defect. RGB is judged against
+                # the measured repeatability floor.
+                if d_rgb > rgb_gate or d_dep != 0.0:
+                    step_bad = True
+                    if diagnosis is None:
+                        diagnosis = snapshot
+                        diagnosis["env_index"] = i
+                        diagnosis["rgb_diff"] = d_rgb
+                        diagnosis["depth_diff"] = d_dep
+
+            if step_bad:
+                mismatched_steps += 1
+    finally:
+        renderer.close()
+        for e in base_envs + shared_envs:
+            e.close()
+
+    return {
+        "n_envs": k,
+        "steps": steps,
+        "shuffled_service_order": shuffle,
+        "want_seg": want_seg,
+        "state_transfer": state_transfer,
+        "frames_compared": compared,
+        "max_rgb_abs_diff": worst_rgb,
+        "max_depth_abs_diff": worst_dep,
+        "rgb_worst_frame_stats": worst_stats,
+        "noise_floor": noise,
+        "rgb_gate": rgb_gate,
+        "mismatched_steps": mismatched_steps,
+        "bit_identical": worst_rgb == 0 and worst_dep == 0.0,
+        "passed": worst_rgb <= rgb_gate and worst_dep == 0.0,
+        "diagnosis": diagnosis,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env", default=DEFAULT_ENV)
+    p.add_argument("--envs", type=int, default=4, help="envs sharing one renderer")
+    p.add_argument("--steps", type=int, default=60)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--seg", action="store_true",
+                   help="also render and compare the segmentation pass")
+    p.add_argument("--state-transfer", default="copy",
+                   choices=SharedStaticRenderer.STATE_TRANSFER_MODES,
+                   help="'copy' transfers the whole MjData (exact); 'minimal' "
+                        "copies qpos and recomputes poses (faster, must be "
+                        "proven here before use)")
+    p.add_argument("--rgb-tol", type=int, default=1,
+                   help="allowed RGB LSB difference. The gate is the larger of "
+                        "this and the measured repeatability floor. Depth is "
+                        "always required to match exactly.")
+    args = p.parse_args()
+
+    env_cls = resolve_env_class(args.env)
+
+    print(f"env={args.env}  k={args.envs}  steps={args.steps}  "
+          f"seg={args.seg}  state_transfer={args.state_transfer}\n")
+
+    results = []
+    for shuffle in (False, True):
+        name = "cross-talk (shuffled order)" if shuffle else "parity (in order)"
+        print(f"[{name}] ...", end="", flush=True)
+        r = run_check(env_cls, args.envs, args.steps, args.seed, shuffle,
+                      args.seg, args.state_transfer, args.rgb_tol)
+        results.append((name, r))
+        st = r["rgb_worst_frame_stats"]
+        print(f" {'PASS' if r['passed'] else 'FAIL'}"
+              f"  rgb_max={r['max_rgb_abs_diff']} (gate {r['rgb_gate']},"
+              f" {st['frac_differing'] * 100:.3f}% of pixels differ,"
+              f" mean {st['mean']:.4f})"
+              f"  depth_max={r['max_depth_abs_diff']:.6g}"
+              f"  ({r['frames_compared']} frames)")
+
+    print()
+    if all(r["passed"] for _, r in results):
+        first = results[0][1]
+        nf = first["noise_floor"]
+        print(f"measured repeatability floor on this GPU: "
+              f"per-env renderer rgb={nf['per_env_renderer']['rgb']:.6g}, "
+              f"shared renderer rgb={nf['shared_renderer']['rgb']:.6g} "
+              f"(same state rendered repeatedly)")
+        if all(r["bit_identical"] for _, r in results):
+            print("ALL CHECKS PASSED — shared renderer is bit-identical.")
+        else:
+            print("ALL CHECKS PASSED — depth exact (geometry and camera pose "
+                  "provably correct); RGB differs only within the measured\n"
+                  "floor, i.e. colour quantisation between independent GL "
+                  "contexts, not an env/image association fault.")
+        return 0
+
+    print("FAILED — do not trust any speed comparison until this passes.\n")
+    for name, r in results:
+        d = r.get("diagnosis")
+        if not d:
+            continue
+        print(f"--- first divergence in '{name}' (env {d['env_index']}, "
+              f"rgb {d['rgb_diff']}, depth {d['depth_diff']:.6g}) ---")
+        print(f"  physics  base vs shared : "
+              + ", ".join(f"{k}={v:.6g}" for k, v in d["physics"].items()))
+        print(f"  transfer env vs scratch : "
+              + ", ".join(f"{k}={v:.6g}" for k, v in d["transfer"].items()))
+        print(f"  => {d['verdict']}")
+        print()
+        break
+
+    if args.state_transfer == "minimal":
+        print("Re-run with --state-transfer copy: if that passes, 'minimal' is "
+              "missing a field that the scene builder reads.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/multi_drone_mujoco/envs/base_aviary.py
+++ b/multi_drone_mujoco/envs/base_aviary.py
@@ -465,6 +465,15 @@ class BaseAviary(gym.Env):
         self._renderer = None
         self._viewer = None
 
+        # Optional shared-renderer delegation (see multi_drone_mujoco.rendering).
+        # When set, _getDroneImages() renders through this object instead of
+        # creating a per-env GL context. Only valid for static worlds -- the
+        # caller asserts that, it is never inferred. None => original behaviour.
+        self._external_renderer = None
+        # Segmentation is rendered by default for backward compatibility, but it
+        # is a full extra render pass and callers that discard it can opt out.
+        self._render_seg = True
+
         # Wind disturbance (set via set_wind() or subclass)
         self._wind_field = None
 
@@ -809,10 +818,17 @@ class BaseAviary(gym.Env):
         ]).reshape(20,)
 
     def _getDroneImages(self, nth_drone):
-        """Render RGB, depth, and segmentation from the nth drone's camera."""
-        if self._renderer is None:
-            self._renderer = mujoco.Renderer(self.model, height=self.IMG_RES[1], width=self.IMG_RES[0])
+        """Render RGB, depth, and segmentation from the nth drone's camera.
 
+        Three behaviours, in priority order:
+
+        1. ``self._external_renderer`` set -> delegate to a shared renderer
+           (one GL context serving many envs). Static worlds only.
+        2. ``self._render_seg`` False -> skip the segmentation render pass and
+           return a zero segmentation buffer. Saves a full pass for callers
+           that discard it.
+        3. otherwise -> original per-env behaviour, unchanged.
+        """
         cam_name = f"drone{nth_drone}_cam"
         cam_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_CAMERA, cam_name)
         if cam_id < 0:
@@ -820,20 +836,31 @@ class BaseAviary(gym.Env):
                     np.ones((self.IMG_RES[1], self.IMG_RES[0]), dtype=np.float32),
                     np.zeros((self.IMG_RES[1], self.IMG_RES[0]), dtype=np.int32))
 
+        if self._external_renderer is not None:
+            return self._external_renderer.render(
+                self.data, cam_name, want_seg=self._render_seg)
+
+        if self._renderer is None:
+            self._renderer = mujoco.Renderer(self.model, height=self.IMG_RES[1], width=self.IMG_RES[0])
+
         self._renderer.update_scene(self.data, camera=cam_name)
         rgb = self._renderer.render()
 
-        # Depth rendering
+        # Depth rendering. The update_scene here looks redundant (same data,
+        # unchanged) -- bench/baseline.py measures what dropping it would save,
+        # but it stays until a pixel test proves depth is unaffected.
         self._renderer.enable_depth_rendering()
         self._renderer.update_scene(self.data, camera=cam_name)
         dep = self._renderer.render()
         self._renderer.disable_depth_rendering()
 
-        # Segmentation rendering
-        self._renderer.enable_segmentation_rendering()
-        self._renderer.update_scene(self.data, camera=cam_name)
-        seg = self._renderer.render()
-        self._renderer.disable_segmentation_rendering()
+        if self._render_seg:
+            self._renderer.enable_segmentation_rendering()
+            self._renderer.update_scene(self.data, camera=cam_name)
+            seg = self._renderer.render()
+            self._renderer.disable_segmentation_rendering()
+        else:
+            seg = np.zeros((self.IMG_RES[1], self.IMG_RES[0]), dtype=np.int32)
 
         return rgb, dep, seg
 

--- a/multi_drone_mujoco/rendering/__init__.py
+++ b/multi_drone_mujoco/rendering/__init__.py
@@ -1,0 +1,14 @@
+"""Shared static-scene rendering.
+
+One GL context serving many environments, instead of one context per env.
+
+Valid only when every participating env has an identical, *static* world and a
+single drone -- the caller asserts this explicitly; it is never auto-detected,
+because a silently-wrong assertion produces wrong pixels rather than an error.
+
+See multi_drone_mujoco/bench/ for the verification and benchmark harnesses.
+"""
+
+from .shared import SharedStaticRenderer, RenderStats
+
+__all__ = ["SharedStaticRenderer", "RenderStats"]

--- a/multi_drone_mujoco/rendering/shared.py
+++ b/multi_drone_mujoco/rendering/shared.py
@@ -99,7 +99,6 @@ class SharedStaticRenderer:
         # Scratch data used only for rendering. Never stepped -- it holds a
         # configuration copied from an env, not an independent simulation.
         self._scratch = mujoco.MjData(model)
-        self._zero_seg = np.zeros((self.height, self.width), dtype=np.int32)
 
         self.stats = RenderStats()
 
@@ -175,7 +174,9 @@ class SharedStaticRenderer:
             seg = self._renderer.render()
             self._renderer.disable_segmentation_rendering()
         else:
-            seg = self._zero_seg
+            # Freshly allocated, matching BaseAviary's per-env path. Handing the
+            # same array to every env would alias across them.
+            seg = np.zeros((self.height, self.width), dtype=np.int32)
 
         t2 = time.perf_counter()
 

--- a/multi_drone_mujoco/rendering/shared.py
+++ b/multi_drone_mujoco/rendering/shared.py
@@ -1,0 +1,226 @@
+"""A single GL context that renders many envs' cameras from one uploaded scene.
+
+Why this exists
+---------------
+With one ``mujoco.Renderer`` per env, running N envs means N GL contexts and N
+copies of the arena geometry and textures in VRAM. For a static world those N
+copies are byte-identical and never change, so VRAM -- not compute -- becomes
+the ceiling on how many envs fit on the card.
+
+``SharedStaticRenderer`` holds *one* model, *one* context and *one* scratch
+``MjData``. To render env i it writes that env's configuration into the scratch
+data, recomputes only what rendering needs (body/geom/camera poses), and
+rasterises. The arena is uploaded once regardless of how many envs it serves.
+
+Correctness requirements (caller's responsibility, asserted not inferred)
+-------------------------------------------------------------------------
+* every env shares an identical model -- same XML, same assets, same options
+* the world is static: nothing moves except via ``qpos`` / mocap
+* the drone camera is a real camera in the model
+
+``assert_compatible()`` checks the parts that are cheaply checkable (model
+sizes and the camera's existence) and raises rather than rendering something
+subtly wrong.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+import numpy as np
+
+import mujoco
+
+
+@dataclass
+class RenderStats:
+    """Timing for one renderer. ``wait_ms`` is filled in by callers that queue."""
+
+    frames: int = 0
+    pose_ms: float = 0.0        # writing state + kinematics
+    raster_ms: float = 0.0      # update_scene + render
+    wait_ms: float = 0.0        # time callers spent queued (set externally)
+    _raster_samples: list = field(default_factory=list, repr=False)
+
+    def as_dict(self) -> dict:
+        n = max(self.frames, 1)
+        s = np.array(self._raster_samples) if self._raster_samples else np.zeros(1)
+        return {
+            "frames": self.frames,
+            "pose_mean_ms": round(self.pose_ms / n, 4),
+            "raster_mean_ms": round(self.raster_ms / n, 4),
+            "raster_p99_ms": round(float(np.percentile(s, 99)), 4),
+            "wait_mean_ms": round(self.wait_ms / n, 4),
+            "fps": round(1000.0 / max(self.raster_ms / n + self.pose_ms / n, 1e-9), 1),
+        }
+
+
+class SharedStaticRenderer:
+    """One GL context + one scene, reused across many envs.
+
+    Parameters
+    ----------
+    model : mujoco.MjModel
+        The shared (static) model. Any participating env's model works, since
+        they are required to be identical.
+    width, height : int
+        Offscreen buffer size. Must match what the envs expect.
+    want_seg : bool
+        Whether the segmentation pass should ever run. When False the pass is
+        skipped entirely and a zero buffer is returned -- callers that discard
+        segmentation should leave this off.
+    """
+
+    #: How much of the calling env's MjData is transferred before rendering.
+    #:
+    #: "copy"    -- mj_copyData: the whole state. Exact by construction, and the
+    #:              only mode that is correct without reasoning about which
+    #:              fields mjv_updateScene happens to read.
+    #: "minimal" -- copy qpos/mocap and recompute poses with mj_kinematics +
+    #:              mj_camlight. Cheaper, but only valid if those are genuinely
+    #:              sufficient. Must be proven with bench/verify.py before use.
+    STATE_TRANSFER_MODES = ("copy", "minimal")
+
+    def __init__(self, model: "mujoco.MjModel", width: int, height: int,
+                 want_seg: bool = False, state_transfer: str = "copy"):
+        if state_transfer not in self.STATE_TRANSFER_MODES:
+            raise ValueError(
+                f"state_transfer must be one of {self.STATE_TRANSFER_MODES}, "
+                f"got {state_transfer!r}")
+        self.model = model
+        self.width = int(width)
+        self.height = int(height)
+        self.default_want_seg = bool(want_seg)
+        self.state_transfer = state_transfer
+
+        self._renderer = mujoco.Renderer(model, height=self.height, width=self.width)
+        # Scratch data used only for rendering. Never stepped -- it holds a
+        # configuration copied from an env, not an independent simulation.
+        self._scratch = mujoco.MjData(model)
+        self._zero_seg = np.zeros((self.height, self.width), dtype=np.int32)
+
+        self.stats = RenderStats()
+
+    # -- validation --------------------------------------------------------
+
+    def assert_compatible(self, other_model: "mujoco.MjModel", cam_name: str) -> None:
+        """Raise if ``other_model`` cannot safely be rendered by this instance.
+
+        Catches the common failure -- a differently-built world -- before it can
+        produce plausible but wrong images. Cannot catch every difference (two
+        models can share sizes yet differ in geometry), which is why the caller
+        must still assert that worlds are identical.
+        """
+        m, o = self.model, other_model
+        for attr in ("nq", "nv", "nbody", "ngeom", "ncam", "nmat", "ntex", "nmesh"):
+            if getattr(m, attr) != getattr(o, attr):
+                raise ValueError(
+                    f"SharedStaticRenderer: model mismatch on {attr} "
+                    f"({getattr(m, attr)} vs {getattr(o, attr)}). Shared rendering "
+                    f"requires identical worlds across envs."
+                )
+        if mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_CAMERA, cam_name) < 0:
+            raise ValueError(
+                f"SharedStaticRenderer: camera {cam_name!r} not present in the "
+                f"shared model."
+            )
+
+    # -- rendering ---------------------------------------------------------
+
+    def render(self, data: "mujoco.MjData", cam_name: str,
+               want_seg: Optional[bool] = None
+               ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Render one env's camera.
+
+        ``data`` belongs to the *calling env*, not to this renderer. Only the
+        configuration is copied across; the scratch data is then brought up to
+        date with the minimum needed for rendering.
+
+        Returns ``(rgb, depth, seg)`` matching BaseAviary._getDroneImages.
+        """
+        if want_seg is None:
+            want_seg = self.default_want_seg
+
+        t0 = time.perf_counter()
+
+        s = self._scratch
+        if self.state_transfer == "copy":
+            # Whole-state copy. Slightly more work than recomputing poses, but
+            # it cannot miss a field that the scene builder reads, which the
+            # "minimal" path demonstrably could.
+            mujoco.mj_copyData(s, self.model, data)
+        else:
+            s.qpos[:] = data.qpos
+            if self.model.nmocap:
+                s.mocap_pos[:] = data.mocap_pos
+                s.mocap_quat[:] = data.mocap_quat
+            mujoco.mj_kinematics(self.model, s)
+            mujoco.mj_camlight(self.model, s)
+
+        t1 = time.perf_counter()
+
+        self._renderer.update_scene(s, camera=cam_name)
+        rgb = self._renderer.render()
+
+        self._renderer.enable_depth_rendering()
+        self._renderer.update_scene(s, camera=cam_name)
+        dep = self._renderer.render()
+        self._renderer.disable_depth_rendering()
+
+        if want_seg:
+            self._renderer.enable_segmentation_rendering()
+            self._renderer.update_scene(s, camera=cam_name)
+            seg = self._renderer.render()
+            self._renderer.disable_segmentation_rendering()
+        else:
+            seg = self._zero_seg
+
+        t2 = time.perf_counter()
+
+        self.stats.frames += 1
+        self.stats.pose_ms += (t1 - t0) * 1e3
+        self.stats.raster_ms += (t2 - t1) * 1e3
+        self.stats._raster_samples.append((t2 - t1) * 1e3)
+
+        return rgb, dep, seg
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def close(self) -> None:
+        if self._renderer is not None:
+            self._renderer.close()
+            self._renderer = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+def attach_shared_renderer(envs, want_seg: bool = False,
+                           renderer: Optional[SharedStaticRenderer] = None,
+                           state_transfer: str = "copy"
+                           ) -> SharedStaticRenderer:
+    """Point a list of same-process envs at one shared renderer.
+
+    The caller is asserting that these envs have identical static worlds.
+    """
+    if not envs:
+        raise ValueError("attach_shared_renderer: no envs given")
+
+    head = envs[0]
+    if renderer is None:
+        renderer = SharedStaticRenderer(
+            head.model, width=int(head.IMG_RES[0]), height=int(head.IMG_RES[1]),
+            want_seg=want_seg, state_transfer=state_transfer,
+        )
+
+    for e in envs:
+        renderer.assert_compatible(e.model, "drone0_cam")
+        e._external_renderer = renderer
+        e._render_seg = want_seg
+
+    return renderer

--- a/multi_drone_mujoco/vec/__init__.py
+++ b/multi_drone_mujoco/vec/__init__.py
@@ -1,0 +1,5 @@
+"""Vectorized env wrappers that control how rendering is distributed."""
+
+from .shared_render_vec import SharedRenderVecEnv
+
+__all__ = ["SharedRenderVecEnv"]

--- a/multi_drone_mujoco/vec/shared_render_vec.py
+++ b/multi_drone_mujoco/vec/shared_render_vec.py
@@ -23,6 +23,7 @@ Only valid for identical static worlds -- see multi_drone_mujoco.rendering.
 from __future__ import annotations
 
 import multiprocessing as mp
+import traceback
 from collections import OrderedDict
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 
@@ -77,14 +78,28 @@ def _split_indices(n_envs: int, n_workers: int) -> List[List[int]]:
 
 def _worker(remote, parent_remote, env_fns_wrapper, want_seg: bool,
             state_transfer: str) -> None:
-    parent_remote.close()
-    env_fns = env_fns_wrapper.var
-    envs = [fn() for fn in env_fns]
+    """Serve one group of envs.
 
-    # One renderer for this whole group. Built after the envs so it can adopt
-    # their model and validate compatibility.
+    Every reply is tagged ``("ok", payload)`` or ``("error", traceback)``. Without
+    that, any exception here would kill the worker silently and leave the parent
+    blocked forever in ``recv()`` -- a hang instead of an error, which is far
+    harder to diagnose than a crash.
+    """
+    parent_remote.close()
+    envs = []
     renderer: Optional[SharedStaticRenderer] = None
+
+    def _fail():
+        try:
+            remote.send(("error", traceback.format_exc()))
+        except Exception:
+            pass
+
+    # Setup is the most likely place to fail (bad model, no GL context, OOM),
+    # and it happens before the parent has asked for anything -- so it needs its
+    # own guard.
     try:
+        envs = [fn() for fn in env_fns_wrapper.var]
         head = envs[0]
         renderer = SharedStaticRenderer(
             head.model,
@@ -97,9 +112,21 @@ def _worker(remote, parent_remote, env_fns_wrapper, want_seg: bool,
             renderer.assert_compatible(e.model, "drone0_cam")
             e._external_renderer = renderer
             e._render_seg = want_seg
+    except Exception:
+        _fail()
+        for e in envs:
+            try:
+                e.close()
+            except Exception:
+                pass
+        return
 
+    try:
         while True:
-            cmd, data = remote.recv()
+            try:
+                cmd, data = remote.recv()
+            except (EOFError, KeyboardInterrupt):
+                break
 
             if cmd == "step":
                 results = []
@@ -112,17 +139,17 @@ def _worker(remote, parent_remote, env_fns_wrapper, want_seg: bool,
                         obs, reset_info = env.reset()
                         info["reset_info"] = reset_info
                     results.append((obs, reward, done, info))
-                remote.send(results)
+                remote.send(("ok", results))
 
             elif cmd == "reset":
                 out = []
                 for env, (seed, options) in zip(envs, data):
                     obs, reset_info = env.reset(seed=seed, options=options)
                     out.append((obs, reset_info))
-                remote.send(out)
+                remote.send(("ok", out))
 
             elif cmd == "render":
-                remote.send([env.render() for env in envs])
+                remote.send(("ok", [env.render() for env in envs]))
 
             elif cmd == "close":
                 for env in envs:
@@ -133,32 +160,35 @@ def _worker(remote, parent_remote, env_fns_wrapper, want_seg: bool,
                 break
 
             elif cmd == "get_spaces":
-                remote.send((envs[0].observation_space, envs[0].action_space))
+                remote.send(("ok", (envs[0].observation_space, envs[0].action_space)))
 
             elif cmd == "get_attr":
-                remote.send([getattr(env, data) for env in envs])
+                remote.send(("ok", [getattr(env, data) for env in envs]))
 
             elif cmd == "set_attr":
                 for env in envs:
                     setattr(env, data[0], data[1])
-                remote.send([None] * len(envs))
+                remote.send(("ok", [None] * len(envs)))
 
             elif cmd == "env_method":
                 name, args, kwargs = data
-                remote.send([getattr(env, name)(*args, **kwargs) for env in envs])
+                remote.send(("ok", [getattr(env, name)(*args, **kwargs) for env in envs]))
 
             elif cmd == "is_wrapped":
                 from stable_baselines3.common import env_util
-                remote.send([env_util.is_wrapped(env, data) for env in envs])
+                remote.send(("ok", [env_util.is_wrapped(env, data) for env in envs]))
 
             elif cmd == "render_stats":
-                remote.send(renderer.stats.as_dict() if renderer else None)
+                remote.send(("ok", renderer.stats.as_dict() if renderer else None))
 
             else:
                 raise NotImplementedError(f"worker: unknown command {cmd}")
 
     except (KeyboardInterrupt, EOFError):
         pass
+    except Exception:
+        # Report rather than die mute, so the parent raises instead of hanging.
+        _fail()
     finally:
         try:
             if renderer is not None:
@@ -226,8 +256,27 @@ class SharedRenderVecEnv(VecEnv):
             work_remote.close()
 
         self.remotes[0].send(("get_spaces", None))
-        observation_space, action_space = self.remotes[0].recv()
+        observation_space, action_space = self._recv(self.remotes[0])
         super().__init__(n_envs, observation_space, action_space)
+
+    @staticmethod
+    def _recv(remote):
+        """Unwrap a worker reply, surfacing worker-side failures as exceptions.
+
+        Without this a crashed worker would leave the parent blocked in recv()
+        forever; here it raises with the child's traceback attached.
+        """
+        try:
+            tag, payload = remote.recv()
+        except EOFError as exc:
+            raise RuntimeError(
+                "SharedRenderVecEnv: a worker exited before replying. It most "
+                "likely failed while building its envs or GL context."
+            ) from exc
+        if tag == "error":
+            raise RuntimeError(
+                "SharedRenderVecEnv: worker raised:\n\n" + str(payload))
+        return payload
 
     # -- stepping ----------------------------------------------------------
 
@@ -237,7 +286,7 @@ class SharedRenderVecEnv(VecEnv):
         self.waiting = True
 
     def step_wait(self) -> VecEnvStepReturn:
-        per_worker = [remote.recv() for remote in self.remotes]
+        per_worker = [self._recv(remote) for remote in self.remotes]
         self.waiting = False
 
         # Flatten back into env order. Groups are contiguous and in order, so
@@ -253,7 +302,7 @@ class SharedRenderVecEnv(VecEnv):
         for remote, group in zip(self.remotes, self.groups):
             payload = [(self._seeds[i], self._options[i]) for i in group]
             remote.send(("reset", payload))
-        per_worker = [remote.recv() for remote in self.remotes]
+        per_worker = [self._recv(remote) for remote in self.remotes]
         results = [r for chunk in per_worker for r in chunk]
         obs = [o for o, _ in results]
         self.reset_infos = [info for _, info in results]
@@ -300,7 +349,7 @@ class SharedRenderVecEnv(VecEnv):
         for remote, _ in targets:
             if id(remote) not in cache:
                 remote.send(("get_attr", attr_name))
-                cache[id(remote)] = remote.recv()
+                cache[id(remote)] = self._recv(remote)
         return [cache[id(remote)][slot] for remote, slot in targets]
 
     def set_attr(self, attr_name: str, value: Any, indices: VecEnvIndices = None) -> None:
@@ -308,7 +357,7 @@ class SharedRenderVecEnv(VecEnv):
         for remote, _ in self._remotes_for(indices):
             if id(remote) not in seen:
                 remote.send(("set_attr", (attr_name, value)))
-                remote.recv()
+                self._recv(remote)
                 seen.add(id(remote))
 
     def env_method(self, method_name: str, *method_args,
@@ -318,7 +367,7 @@ class SharedRenderVecEnv(VecEnv):
         for remote, _ in targets:
             if id(remote) not in cache:
                 remote.send(("env_method", (method_name, method_args, method_kwargs)))
-                cache[id(remote)] = remote.recv()
+                cache[id(remote)] = self._recv(remote)
         return [cache[id(remote)][slot] for remote, slot in targets]
 
     def env_is_wrapped(self, wrapper_class, indices: VecEnvIndices = None) -> List[bool]:
@@ -327,7 +376,7 @@ class SharedRenderVecEnv(VecEnv):
         for remote, _ in targets:
             if id(remote) not in cache:
                 remote.send(("is_wrapped", wrapper_class))
-                cache[id(remote)] = remote.recv()
+                cache[id(remote)] = self._recv(remote)
         return [cache[id(remote)][slot] for remote, slot in targets]
 
     # -- diagnostics -------------------------------------------------------
@@ -336,4 +385,4 @@ class SharedRenderVecEnv(VecEnv):
         """Per-worker renderer timings -- frames, raster ms, p99, fps."""
         for remote in self.remotes:
             remote.send(("render_stats", None))
-        return [remote.recv() for remote in self.remotes]
+        return [self._recv(remote) for remote in self.remotes]

--- a/multi_drone_mujoco/vec/shared_render_vec.py
+++ b/multi_drone_mujoco/vec/shared_render_vec.py
@@ -1,0 +1,339 @@
+"""VecEnv that runs N envs across M worker processes, one GL context each.
+
+Contrast with ``SubprocVecEnv``, which puts one env in each process and so
+creates N GL contexts and N copies of the arena in VRAM.
+
+Here N envs are split into M groups. Each worker process holds its group's envs
+and a single :class:`SharedStaticRenderer`, so VRAM cost scales with **M, not
+N** -- which is what lets N grow past the point where VRAM currently stops it.
+
+Total rasterisation work is unchanged: N images per vec step either way. What
+changes is context count, VRAM, and CPU-side scene setup.
+
+Choosing M
+----------
+M is both the render-context count and the physics-process count, so it trades
+VRAM against physics parallelism. ``multi_drone_mujoco/bench/calibrate.py``
+sweeps it and reports the wait-time curve; pick the smallest M whose per-step
+wait stays flat.
+
+Only valid for identical static worlds -- see multi_drone_mujoco.rendering.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from collections import OrderedDict
+from typing import Any, Callable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import gymnasium as gym
+
+from stable_baselines3.common.vec_env.base_vec_env import (
+    VecEnv, CloudpickleWrapper, VecEnvIndices, VecEnvObs, VecEnvStepReturn,
+)
+
+from multi_drone_mujoco.rendering import SharedStaticRenderer
+
+
+# --------------------------------------------------------------------------
+# observation stacking
+# --------------------------------------------------------------------------
+
+def _stack_obs(obs_list: List[Any], space: gym.Space):
+    """Stack a list of per-env observations into batched form.
+
+    Implemented locally rather than importing SB3's private ``_flatten_obs`` so
+    an SB3 refactor cannot silently break the render path.
+    """
+    if isinstance(space, gym.spaces.Dict):
+        return OrderedDict(
+            (k, np.stack([o[k] for o in obs_list])) for k in space.spaces.keys()
+        )
+    if isinstance(space, gym.spaces.Tuple):
+        n = len(space.spaces)
+        return tuple(np.stack([o[i] for o in obs_list]) for i in range(n))
+    return np.stack(obs_list)
+
+
+def _split_indices(n_envs: int, n_workers: int) -> List[List[int]]:
+    """Split env indices into n_workers contiguous, near-equal groups."""
+    if n_workers < 1:
+        raise ValueError("n_workers must be >= 1")
+    if n_workers > n_envs:
+        n_workers = n_envs
+    base, extra = divmod(n_envs, n_workers)
+    groups, start = [], 0
+    for w in range(n_workers):
+        size = base + (1 if w < extra else 0)
+        groups.append(list(range(start, start + size)))
+        start += size
+    return groups
+
+
+# --------------------------------------------------------------------------
+# worker
+# --------------------------------------------------------------------------
+
+def _worker(remote, parent_remote, env_fns_wrapper, want_seg: bool,
+            state_transfer: str) -> None:
+    parent_remote.close()
+    env_fns = env_fns_wrapper.var
+    envs = [fn() for fn in env_fns]
+
+    # One renderer for this whole group. Built after the envs so it can adopt
+    # their model and validate compatibility.
+    renderer: Optional[SharedStaticRenderer] = None
+    try:
+        head = envs[0]
+        renderer = SharedStaticRenderer(
+            head.model,
+            width=int(head.IMG_RES[0]),
+            height=int(head.IMG_RES[1]),
+            want_seg=want_seg,
+            state_transfer=state_transfer,
+        )
+        for e in envs:
+            renderer.assert_compatible(e.model, "drone0_cam")
+            e._external_renderer = renderer
+            e._render_seg = want_seg
+
+        while True:
+            cmd, data = remote.recv()
+
+            if cmd == "step":
+                results = []
+                for env, action in zip(envs, data):
+                    obs, reward, terminated, truncated, info = env.step(action)
+                    done = terminated or truncated
+                    info["TimeLimit.truncated"] = truncated and not terminated
+                    if done:
+                        info["terminal_observation"] = obs
+                        obs, reset_info = env.reset()
+                        info["reset_info"] = reset_info
+                    results.append((obs, reward, done, info))
+                remote.send(results)
+
+            elif cmd == "reset":
+                out = []
+                for env, (seed, options) in zip(envs, data):
+                    obs, reset_info = env.reset(seed=seed, options=options)
+                    out.append((obs, reset_info))
+                remote.send(out)
+
+            elif cmd == "render":
+                remote.send([env.render() for env in envs])
+
+            elif cmd == "close":
+                for env in envs:
+                    env.close()
+                if renderer is not None:
+                    renderer.close()
+                remote.close()
+                break
+
+            elif cmd == "get_spaces":
+                remote.send((envs[0].observation_space, envs[0].action_space))
+
+            elif cmd == "get_attr":
+                remote.send([getattr(env, data) for env in envs])
+
+            elif cmd == "set_attr":
+                for env in envs:
+                    setattr(env, data[0], data[1])
+                remote.send([None] * len(envs))
+
+            elif cmd == "env_method":
+                name, args, kwargs = data
+                remote.send([getattr(env, name)(*args, **kwargs) for env in envs])
+
+            elif cmd == "is_wrapped":
+                from stable_baselines3.common import env_util
+                remote.send([env_util.is_wrapped(env, data) for env in envs])
+
+            elif cmd == "render_stats":
+                remote.send(renderer.stats.as_dict() if renderer else None)
+
+            else:
+                raise NotImplementedError(f"worker: unknown command {cmd}")
+
+    except (KeyboardInterrupt, EOFError):
+        pass
+    finally:
+        try:
+            if renderer is not None:
+                renderer.close()
+            for env in envs:
+                env.close()
+        except Exception:
+            pass
+
+
+# --------------------------------------------------------------------------
+# VecEnv
+# --------------------------------------------------------------------------
+
+class SharedRenderVecEnv(VecEnv):
+    """N envs over M processes, each process owning one shared GL context.
+
+    Parameters
+    ----------
+    env_fns : list of callables
+        One factory per env, as with SubprocVecEnv.
+    n_workers : int
+        M -- number of processes, and therefore of GL contexts. Must be <= N.
+        ``n_workers == len(env_fns)`` reproduces SubprocVecEnv's context count
+        (useful as a control in benchmarks).
+    want_seg : bool
+        Render the segmentation pass. Off by default -- most callers discard it
+        and it costs a full extra pass.
+    start_method : str, optional
+        Defaults to forkserver where available, else spawn (matching SB3).
+    """
+
+    def __init__(self, env_fns: List[Callable[[], gym.Env]], n_workers: int,
+                 want_seg: bool = False, start_method: Optional[str] = None,
+                 state_transfer: str = "copy"):
+        self.waiting = False
+        self.closed = False
+        n_envs = len(env_fns)
+
+        if n_workers > n_envs:
+            raise ValueError(f"n_workers ({n_workers}) > n_envs ({n_envs})")
+
+        self.groups = _split_indices(n_envs, n_workers)
+        self.n_workers = len(self.groups)
+
+        if start_method is None:
+            methods = mp.get_all_start_methods()
+            start_method = "forkserver" if "forkserver" in methods else "spawn"
+        ctx = mp.get_context(start_method)
+
+        self.remotes, self.work_remotes, self.processes = [], [], []
+        for group in self.groups:
+            remote, work_remote = ctx.Pipe()
+            fns = [env_fns[i] for i in group]
+            proc = ctx.Process(
+                target=_worker,
+                args=(work_remote, remote, CloudpickleWrapper(fns), want_seg,
+                      state_transfer),
+                daemon=True,
+            )
+            proc.start()
+            self.remotes.append(remote)
+            self.work_remotes.append(work_remote)
+            self.processes.append(proc)
+            work_remote.close()
+
+        self.remotes[0].send(("get_spaces", None))
+        observation_space, action_space = self.remotes[0].recv()
+        super().__init__(n_envs, observation_space, action_space)
+
+    # -- stepping ----------------------------------------------------------
+
+    def step_async(self, actions: np.ndarray) -> None:
+        for remote, group in zip(self.remotes, self.groups):
+            remote.send(("step", [actions[i] for i in group]))
+        self.waiting = True
+
+    def step_wait(self) -> VecEnvStepReturn:
+        per_worker = [remote.recv() for remote in self.remotes]
+        self.waiting = False
+
+        # Flatten back into env order. Groups are contiguous and in order, so
+        # concatenation restores the caller's indexing exactly.
+        results = [r for chunk in per_worker for r in chunk]
+        obs, rews, dones, infos = zip(*results)
+        return (_stack_obs(list(obs), self.observation_space),
+                np.array(rews, dtype=np.float32),
+                np.array(dones, dtype=bool),
+                list(infos))
+
+    def reset(self) -> VecEnvObs:
+        for remote, group in zip(self.remotes, self.groups):
+            payload = [(self._seeds[i], self._options[i]) for i in group]
+            remote.send(("reset", payload))
+        per_worker = [remote.recv() for remote in self.remotes]
+        results = [r for chunk in per_worker for r in chunk]
+        obs = [o for o, _ in results]
+        self.reset_infos = [info for _, info in results]
+        self._reset_seeds()
+        self._reset_options()
+        return _stack_obs(obs, self.observation_space)
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        if self.waiting:
+            for remote in self.remotes:
+                try:
+                    remote.recv()
+                except EOFError:
+                    pass
+        for remote in self.remotes:
+            try:
+                remote.send(("close", None))
+            except (BrokenPipeError, OSError):
+                pass
+        for proc in self.processes:
+            proc.join(timeout=5.0)
+            if proc.is_alive():
+                proc.terminate()
+        self.closed = True
+
+    # -- introspection -----------------------------------------------------
+
+    def _remotes_for(self, indices: VecEnvIndices):
+        """Map env indices to (remote, local_slot) pairs."""
+        indices = self._get_indices(indices)
+        out = []
+        for i in indices:
+            for w, group in enumerate(self.groups):
+                if i in group:
+                    out.append((self.remotes[w], group.index(i)))
+                    break
+        return out
+
+    def get_attr(self, attr_name: str, indices: VecEnvIndices = None) -> List[Any]:
+        targets = self._remotes_for(indices)
+        cache = {}
+        for remote, _ in targets:
+            if id(remote) not in cache:
+                remote.send(("get_attr", attr_name))
+                cache[id(remote)] = remote.recv()
+        return [cache[id(remote)][slot] for remote, slot in targets]
+
+    def set_attr(self, attr_name: str, value: Any, indices: VecEnvIndices = None) -> None:
+        seen = set()
+        for remote, _ in self._remotes_for(indices):
+            if id(remote) not in seen:
+                remote.send(("set_attr", (attr_name, value)))
+                remote.recv()
+                seen.add(id(remote))
+
+    def env_method(self, method_name: str, *method_args,
+                   indices: VecEnvIndices = None, **method_kwargs) -> List[Any]:
+        targets = self._remotes_for(indices)
+        cache = {}
+        for remote, _ in targets:
+            if id(remote) not in cache:
+                remote.send(("env_method", (method_name, method_args, method_kwargs)))
+                cache[id(remote)] = remote.recv()
+        return [cache[id(remote)][slot] for remote, slot in targets]
+
+    def env_is_wrapped(self, wrapper_class, indices: VecEnvIndices = None) -> List[bool]:
+        targets = self._remotes_for(indices)
+        cache = {}
+        for remote, _ in targets:
+            if id(remote) not in cache:
+                remote.send(("is_wrapped", wrapper_class))
+                cache[id(remote)] = remote.recv()
+        return [cache[id(remote)][slot] for remote, slot in targets]
+
+    # -- diagnostics -------------------------------------------------------
+
+    def render_stats(self) -> List[dict]:
+        """Per-worker renderer timings -- frames, raster ms, p99, fps."""
+        for remote in self.remotes:
+            remote.send(("render_stats", None))
+        return [remote.recv() for remote in self.remotes]


### PR DESCRIPTION
---
Problem

With one mujoco.Renderer per env, running N envs creates N GL contexts and N byte-identical copies of the arena geometry and textures in VRAM. In a static world those copies never change, so VRAM — not compute — becomes the ceiling on how many envs fit on the card. You run out of memory well before you run out of GPU.

What this adds

rendering/shared.py — SharedStaticRenderer: one model, one GL context, one scratch MjData, serving many envs from a single uploaded scene. The arena is uploaded once regardless of how many envs use it.

vec/shared_render_vec.py — SharedRenderVecEnv: runs N envs across M worker processes with one renderer each, so VRAM scales with M instead of N. Drop-in for SubprocVecEnv (same SB3 VecEnv API):

from multi_drone_mujoco.vec import SharedRenderVecEnv
venv = SharedRenderVecEnv(env_fns, n_workers=M, want_seg=False)

bench/ — the harnesses used to validate and size it: verify (correctness), baseline (current cost), calibrate (picks M from measured latency), compare (old vs new, interleaved). BenchAviary is a self-contained static fixture using procedural textures, so the benchmarks need no external asset files.

envs/base_aviary.py — two hooks, both defaulting to existing behaviour:

┌────────────────────┬────────────────────────────────────────────────────────────────────────────┐
│     attribute      │                                   effect                                   │
├────────────────────┼────────────────────────────────────────────────────────────────────────────┤
│ _external_renderer │ delegate rendering instead of building a per-env context                   │
├────────────────────┼────────────────────────────────────────────────────────────────────────────┤
│ _render_seg        │ skip the segmentation pass — a full extra render that most callers discard │
└────────────────────┴────────────────────────────────────────────────────────────────────────────┘

What this is not

It does not reduce rasterisation work: N envs still need N images per step. What drops is GL context count, VRAM, and CPU-side scene setup. The payoff is being able to raise N, not making a fixed N faster. Any speedup at constant N is a secondary effect of reduced context switching.

Correctness

Valid only for identical static worlds. The caller asserts that explicitly — it is never auto-detected, because a wrong assertion produces wrong pixels rather than an error. assert_compatible() checks the cheaply-checkable part (model sizes, camera presence) and raises rather than rendering something subtly wrong.

bench/verify.py runs two checks against the per-env renderer:

1. parity — identical action sequences through both paths, compared frame by frame
2. cross-talk — the same test with the shared renderer's service order shuffled every step, which catches state leaking between envs

Two findings worth recording

State transfer must be a whole-MjData copy. Copying qpos and recomputing poses with mj_kinematics + mj_camlight looked sufficient and was not — it produced a badly wrong scene (depth off by ~578). mj_copyData is the default; the cheaper path remains available as state_transfer="minimal", but has to pass bench/verify before use.

Two independent GL contexts are not bit-identical. Given the same state, model and camera, depth matches exactly while RGB differs by ~1 LSB. A correctness test therefore cannot demand bitwise RGB equality: verify measures each path's own repeatability first and judges against that floor, while requiring depth to match exactly. Depth is what actually proves correctness — it encodes geometry and camera pose, so an env↔image association fault shows up there enormously and cannot hide behind colour rounding.

Measurements

verify passes and the vectorised path runs end-to-end. Throughput and VRAM numbers from a full sweep are still to come; the benchmarks are included so they can be reproduced directly:

python -m multi_drone_mujoco.bench.baseline  --envs 1,8,16,30
python -m multi_drone_mujoco.bench.calibrate --n-envs 30
python -m multi_drone_mujoco.bench.compare   --n-envs 30 --workers <M>

compare reports peak VRAM per path and extrapolates how many envs fit on the card under each.

Compatibility

Fully backward compatible. Both base_aviary hooks default to current behaviour, so existing envs are unaffected unless they opt in. No public API changes and no new required dependencies — pynvml / psutil / matplotlib are optional and only enrich benchmark output.

Limitations

- M is both the GL-context count and the physics-process count, so the two cannot be tuned apart. This only matters if calibrate recommends an M well below the core count — it says so explicitly when it does. Decoupling them would need a render-server design, which is out of scope here.
- The update_scene before the depth pass looks redundant. baseline.py prices it, but it is left in until a pixel test proves depth is unaffected.

See multi_drone_mujoco/bench/TEST.md for the run order.